### PR TITLE
Add an option to invert the whitelist operation mode

### DIFF
--- a/SlowQuitApps/SQAAppDelegate.m
+++ b/SlowQuitApps/SQAAppDelegate.m
@@ -98,12 +98,14 @@ BOOL shouldHandleCmdQ() {
     if ([activeApp.bundleIdentifier isEqualToString:@"com.apple.finder"]) {
         return NO;
     }
+
+    BOOL invertList = [SQAPreferences invertList];
     for (NSString *bundleId in [SQAPreferences whitelist]) {
         if ([activeApp.bundleIdentifier isEqualToString:bundleId]) {
-            return NO;
+            return (invertList ?  YES : NO);
         }
     }
-    return YES;
+    return (invertList ?  NO : YES);
 }
 
 OSStatus cmdQHandler(EventHandlerCallRef nextHandler, EventRef anEvent, void *userData) {

--- a/SlowQuitApps/SQAPreferences.h
+++ b/SlowQuitApps/SQAPreferences.h
@@ -4,5 +4,5 @@
 
 + (NSInteger)delay;
 + (NSArray<NSString *> *)whitelist;
-
++ (BOOL)invertList;
 @end

--- a/SlowQuitApps/SQAPreferences.m
+++ b/SlowQuitApps/SQAPreferences.m
@@ -6,7 +6,7 @@
 + (NSUserDefaults *)defaults {
     static BOOL defaultsRegistered;
     if (!defaultsRegistered) {
-        [[NSUserDefaults standardUserDefaults] registerDefaults:@{@"delay": @1000, @"whitelist": @[]}];
+        [[NSUserDefaults standardUserDefaults] registerDefaults:@{@"delay": @1000, @"whitelist": @[], @"invertList": @NO}];
         defaultsRegistered = YES;
     }
     return [NSUserDefaults standardUserDefaults];
@@ -31,5 +31,12 @@
     return whitelist;
 }
 
++ (BOOL)invertList {
+    static BOOL invertList;
+    if (!invertList) {
+        invertList = [[self defaults] boolForKey:@"invertList"];
+    }
+    return invertList;
+}
 
 @end


### PR DESCRIPTION
Now, when the defaults property 'invertList' is set to true, SQA functions only for the apps listed in the 'whitelist' and no other. See #27.