### PR TITLE
Configuration option for hiding overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,8 @@ To switch off this mode:
 
     $ defaults delete com.dteoh.SlowQuitApps invertList
 
+#### Hide overlay
+
+By default, an overlay with an indicator of the time remaining until the app gets closed appears. To hide this overlay, run the following command:
+
+    $ defaults write com.dteoh.SlowQuitApps displayOverlay -bool NO

--- a/SlowQuitApps/SQAAppDelegate.m
+++ b/SlowQuitApps/SQAAppDelegate.m
@@ -21,9 +21,11 @@
 - (id)init {
     self = [super init];
     if (self) {
-        overlayView = [[SQAOverlayWindowController alloc] init];
         terminator = [[SQATerminator alloc] init];
         qResolver = [[SQAQResolver alloc] init];
+        if ([SQAPreferences displayOverlay]) {
+            overlayView = [[SQAOverlayWindowController alloc] init];
+        }
     }
     return self;
 }
@@ -68,13 +70,19 @@
 
 - (void)cmdQPressed {
     __weak typeof(terminator) weakTerminator = terminator;
-    __weak typeof (overlayView) weakOverlay = overlayView;
+    __weak typeof(overlayView) weakOverlay = overlayView;
 
-    [terminator newMission:^{
-        [weakOverlay hideOverlay];
-        [weakOverlay resetOverlay];
-    }];
-    [overlayView showOverlay:terminator.missionDurationInSeconds];
+    void (^hideOverlay)(void) = ^{
+        if (overlayView) {
+            [weakOverlay hideOverlay];
+            [weakOverlay resetOverlay];
+        }
+    };
+
+    [terminator newMission:hideOverlay];
+    if (overlayView) {
+        [overlayView showOverlay:terminator.missionDurationInSeconds];
+    }
 
     stream = [[SQACmdQStream alloc] initWithQResolver:qResolver];
     __weak typeof(stream) weakStream = stream;
@@ -83,8 +91,7 @@
         if (pressed) {
             [weakTerminator updateMission];
         } else {
-            [weakOverlay hideOverlay];
-            [weakOverlay resetOverlay];
+            hideOverlay();
             [weakStream close];
         }
     };

--- a/SlowQuitApps/SQAPreferences.h
+++ b/SlowQuitApps/SQAPreferences.h
@@ -3,6 +3,7 @@
 @interface SQAPreferences : NSObject
 
 + (NSInteger)delay;
++ (BOOL)displayOverlay;
 + (NSArray<NSString *> *)whitelist;
 + (BOOL)invertList;
 

--- a/SlowQuitApps/SQAPreferences.m
+++ b/SlowQuitApps/SQAPreferences.m
@@ -6,10 +6,19 @@
 + (NSUserDefaults *)defaults {
     static BOOL defaultsRegistered;
     if (!defaultsRegistered) {
-        [[NSUserDefaults standardUserDefaults] registerDefaults:@{@"delay": @1000, @"whitelist": @[], @"invertList": @NO}];
+      NSDictionary *defaults = @{@"delay": @1000, @"whitelist": @[], @"invertList": @NO, @"displayOverlay": @YES};
+      [[NSUserDefaults standardUserDefaults] registerDefaults:defaults];
         defaultsRegistered = YES;
     }
     return [NSUserDefaults standardUserDefaults];
+}
+
++ (BOOL)displayOverlay {
+    static BOOL displayOverlay;
+    if (!displayOverlay) {
+        displayOverlay = [[self defaults] boolForKey:@"displayOverlay"];
+    }
+    return displayOverlay;
 }
 
 + (NSInteger)delay {


### PR DESCRIPTION
This PR introduces a new configuration option called `displayOverlay`, which specifies whether the overlay gets shown or not. By default the overlay is shown.

Implements request of #36 